### PR TITLE
Updated podspec to allow OSX deployment targets

### DIFF
--- a/SLObjectiveCRuntimeAdditions.podspec
+++ b/SLObjectiveCRuntimeAdditions.podspec
@@ -1,15 +1,14 @@
 Pod::Spec.new do |s|
-  s.name         = "SLObjectiveCRuntimeAdditions"
-  s.version      = "1.1.0"
-  s.summary      = "Objc runtime additions."
-  s.homepage     = "https://github.com/OliverLetterer/SLObjectiveCRuntimeAdditions"
-  s.license      = 'MIT'
-  s.author       = { "Oliver Letterer" => "oliver.letterer@gmail.com" }
-  s.source       = { :git => "https://github.com/OliverLetterer/SLObjectiveCRuntimeAdditions.git", :tag => s.version.to_s }
-  s.platform     = :ios, '5.0'
-
-  s.source_files  = 'SLObjectiveCRuntimeAdditions'
-
-  s.requires_arc = true
-  s.frameworks = 'Foundation'
+  s.name                  = "SLObjectiveCRuntimeAdditions"
+  s.version               = "1.1.0"
+  s.summary               = "Objc runtime additions."
+  s.homepage              = "https://github.com/OliverLetterer/SLObjectiveCRuntimeAdditions"
+  s.license               = 'MIT'
+  s.author                = { "Oliver Letterer" => "oliver.letterer@gmail.com" }
+  s.source                = { :git => "https://github.com/OliverLetterer/SLObjectiveCRuntimeAdditions.git", :tag => s.version.to_s }
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.6'
+  s.source_files          = 'SLObjectiveCRuntimeAdditions'
+  s.requires_arc          = true
+  s.frameworks            = 'Foundation'
 end


### PR DESCRIPTION
I've added support for OSX deployment targets.

There is no reason that this podspec should be iOS only. It works fine in OSX apps :)
