### PR TITLE
Fix for uncaught exception on iOS 5 when using class names for block arguments

### DIFF
--- a/SLObjectiveCRuntimeAdditions/SLBlockDescription.m
+++ b/SLObjectiveCRuntimeAdditions/SLBlockDescription.m
@@ -9,6 +9,25 @@
 #import "SLBlockDescription.h"
 #import <Foundation/Foundation.h>
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+NS_INLINE const char * remove_quoted_parts(const char *str){
+    char *result = malloc(strlen(str) + 1);
+    BOOL skip = NO;
+    char *to = result;
+    char c;
+    while ((c = *str++)) {
+        if ('"' == c) {
+            skip = !skip;
+            continue;
+        }
+        if (skip) continue;
+        *to++ = c;
+    }
+    *to = '\0';
+    return result;
+}
+#endif
+
 @implementation SLBlockDescription
 
 - (id)initWithBlock:(id)block
@@ -31,6 +50,12 @@
             }
             
             const char *signature = (*(const char **)signatureLocation);
+            
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+            // NSMethodSignature on iOS 5 can not handle quoted class names
+            signature = remove_quoted_parts(signature);
+#endif
+            
             _blockSignature = [NSMethodSignature signatureWithObjCTypes:signature];
         }
     }

--- a/Tests/SLObjectiveCRuntimeAdditionsTests.m
+++ b/Tests/SLObjectiveCRuntimeAdditionsTests.m
@@ -45,6 +45,14 @@
     }
 }
 
+- (void)testBlockDescriptionCanHandleSpecifiedClasses{
+    NSString *(^testBlock)(NSString *) = ^NSString *(NSString *str) {
+        return @"Test";
+    };
+    
+    STAssertNoThrow([[SLBlockDescription alloc] initWithBlock:testBlock], @"SLBlockDescription fails when class names are specified.");
+}
+
 - (void)testBlockSwizzling
 {
     Class class = [SLTestSwizzleClass class];


### PR DESCRIPTION
NSMethodSignature on iOS 5 can not handle quoted class names in objc types and fails with exception:

``` objective-c
SLBlockDescription *descr = [[SLBlockDescription alloc] initWithBlock:^(NSString *str){}];
```

```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '+[NSMethodSignature signatureWithObjCTypes:]: unsupported type encoding spec '"' in '"NSString"4''
```

So I removed quoted parts from objc type.

And because iOS 5 is far from been mainstream and the fact that the class of the argument may be useful in some cases, I used compile-time check for iOS Deployment Target. 
